### PR TITLE
fix weapon_bandage_sh heal when standing up and holding +attack2 same time

### DIFF
--- a/lua/weapons/weapon_bandage_sh.lua
+++ b/lua/weapons/weapon_bandage_sh.lua
@@ -344,8 +344,8 @@ function SWEP:SecondaryAttack()
 		local ent = hg.eyeTrace(self:GetOwner()).Entity
 		self.healbuddy = ent
 		if !IsValid(self.healbuddy) then return end
+		if hg.GetCurrentCharacter(self.healbuddy) == hg.GetCurrentCharacter(self:GetOwner()) then return end
 		local done = self:Heal(self.healbuddy, self.mode)
-
 		if(done and self.PostHeal)then
 			self:PostHeal(self.healbuddy, self.mode)
 		end		


### PR DESCRIPTION
if you have in your hands an any item that inherits from weapon_bandage_sh and you hold +attack2 when standing up, the SWEP:SecondaryAttack will be called on you and SWEP:Heal you
p.s: sorry for previous 2 pr's, had some problems with sending it