### PR TITLE
Update sh_attachment.lua

### DIFF
--- a/lua/weapons/homigrad_base/sh_attachment.lua
+++ b/lua/weapons/homigrad_base/sh_attachment.lua
@@ -69,6 +69,36 @@ function hg.ClearAttachments(wep)
 	return tbl.attachments
 end
 
+function hg.NormalizeAttachments(wep, attachments)
+	if isstring(wep) then
+		wep = weapons.Get(wep)
+	end
+
+	if not istable(attachments) then
+		attachments = {}
+	end
+
+	if not wep then return attachments end
+
+	wep.availableAttachments = wep.availableAttachments or {}
+
+	attachments.barrel = attachments.barrel or {}
+	attachments.sight = attachments.sight or {}
+	attachments.mount = attachments.mount or {}
+	attachments.grip = attachments.grip or {}
+	attachments.underbarrel = attachments.underbarrel or {}
+	attachments.magwell = attachments.magwell or {}
+
+	if SERVER then
+		local available = wep.availableAttachments
+		if table.IsEmpty(attachments.barrel) then attachments.barrel = available.barrel and available.barrel["empty"] or {} end
+		if table.IsEmpty(attachments.sight) then attachments.sight = available.sight and available.sight["empty"] or {} end
+		if table.IsEmpty(attachments.mount) then attachments.mount = available.mount and available.mount["empty"] or {} end
+	end
+
+	return attachments
+end
+
 function hg.SetAttachment(tbl,att,wep)
 	if not wep then return end
 	local wep = weapons.Get(wep)


### PR DESCRIPTION
1/3 частей фикса - 
Проблема что после смерти если в оружие не было патрон или на нем были атачменты, то в нем появляются патроны а атачменты пропадают и так же не надеваются атачменты на это оружие с ошибкой: net message "ZB_AttachAdd" (64 Bytes) from Player [1][Pathetic] (STEAM_0:0:602806151) errored: stack traceback: lua/homigrad/sv_anti_exploit.lua:99: in function '__index' lua/weapons/homigrad_base/sv_attachment.lua:44: in function 'AddAttachment' lua/weapons/homigrad_base/sv_attachment.lua:19: in function <lua/weapons/homigrad_base/sv_attachment.lua:16> [C]: in function 'xpcall' lua/homigrad/sv_anti_exploit.lua:96: in function <lua/homigrad/sv_anti_exploit.lua:60>[net] блокируем дальнейшие сообщения Pathetic на 1 сек. 
