### PR TITLE
Update shared.lua

### DIFF
--- a/lua/weapons/homigrad_base/shared.lua
+++ b/lua/weapons/homigrad_base/shared.lua
@@ -664,10 +664,35 @@ end
 
 function SWEP:SetInfo(info)
 	if not info then return end
-	self:SetClip1(info[1] or self:GetMaxClip1())
-	self.attachments = info[2] or {}
+
+	if isentity(info) then
+		if IsValid(info) and info.GetInfo then
+			info = info:GetInfo()
+		else
+			return
+		end
+	end
+
+	if not istable(info) then return end
+
+	local clip = info[1]
+	if clip == nil then
+		clip = self:GetMaxClip1()
+	end
+
+	self:SetClip1(clip)
+
+	local attachments = info[2]
+	if not istable(attachments) then
+		attachments = hg.ClearAttachments(self.ClassName)
+	else
+		attachments = hg.NormalizeAttachments(self, attachments)
+	end
+
+	self.attachments = attachments
 	self:SetNetVar("attachments", self.attachments)
 end
+
 
 local colBlack = Color(0, 0, 0, 125)
 local colWhite = Color(255, 255, 255, 255)


### PR DESCRIPTION
2/3 - 
Проблема что после смерти если в оружие не было патрон или на нем были атачменты, то в нем появляются патроны а атачменты пропадают и так же не надеваются атачменты на это оружие с ошибкой: net message "ZB_AttachAdd" (64 Bytes) from Player [1][Pathetic] (STEAM_0:0:602806151) errored: stack traceback: lua/homigrad/sv_anti_exploit.lua:99: in function '__index' lua/weapons/homigrad_base/sv_attachment.lua:44: in function 'AddAttachment' lua/weapons/homigrad_base/sv_attachment.lua:19: in function <lua/weapons/homigrad_base/sv_attachment.lua:16> [C]: in function 'xpcall' lua/homigrad/sv_anti_exploit.lua:96: in function <lua/homigrad/sv_anti_exploit.lua:60>[net] блокируем дальнейшие сообщения Pathetic на 1 сек. 