### PR TITLE
fix fn45 attachments and eject position

### DIFF
--- a/lua/weapons/weapon_fn45.lua
+++ b/lua/weapons/weapon_fn45.lua
@@ -108,7 +108,8 @@ SWEP.availableAttachments = {
 		["mount"] = {["picatinny"] = Vector(-3.5, 1.75, 0.05), ["pistolmount"] = Vector(-4.5, -0.4, 0.05)}
 	},
 	underbarrel = {
-		["mount"] = Vector(9.8, -0.6, -0.8),
+		[1] = {"laser5", Vector(0,0.25,0.2), {}},
+		["mount"] = Vector(12.5, -1, -1),
 		["mountAngle"] = Angle(0, 0, 90),
 		["mountType"] = "picatinny_small"
 	},


### PR DESCRIPTION
fixes #74 

eject position
<img width="498" height="484" alt="image" src="https://github.com/user-attachments/assets/c5fd95fa-d587-4025-918f-09c356a1e3a1" />
<img width="618" height="668" alt="image" src="https://github.com/user-attachments/assets/17cdf1e5-9ade-44a1-8a1f-665212a1624e" />

barrel
<img width="643" height="499" alt="image" src="https://github.com/user-attachments/assets/8621737d-9b29-4811-9d2c-45e805aef29b" />

sight
picatinny
<img width="452" height="573" alt="image" src="https://github.com/user-attachments/assets/d430c1bf-2717-4718-869f-b431516eb8a4" />

pistolmount
<img width="447" height="436" alt="image" src="https://github.com/user-attachments/assets/6b40754e-6948-4beb-91b8-0707a9576233" />

underbarrel
<img width="665" height="595" alt="image" src="https://github.com/user-attachments/assets/bd54c2f5-f496-44e9-919a-9df50f51eb00" />
