### PR TITLE
Fix  hg_show_hitbox_dir 1 with scope

### DIFF
--- a/lua/weapons/homigrad_base/cl_optics.lua
+++ b/lua/weapons/homigrad_base/cl_optics.lua
@@ -1,6 +1,7 @@
 AddCSLuaFile()
 --
 local delta = 0
+local color_red = Color(255, 0, 0)
 
 hook.Add("HG.InputMouseApply", "ChangeZoom", function(tbl)
 	local ply = LocalPlayer()


### PR DESCRIPTION
[zcity] lua/includes/modules/draw.lua:180: attempt to index local 'color' (a nil value)
  1. RoundedBox - lua/includes/modules/draw.lua:180
   2. DoRT - addons/zcity/lua/weapons/homigrad_base/cl_optics.lua:234
    3. unknown - addons/zcity/lua/weapons/homigrad_base/shared.lua:921
     4. render_RenderView - [C]:-1
      5. v - addons/zcity/lua/homigrad/cl_camera.lua:723
       6. unknown - lua/includes/modules/hook.lua:102