### PR TITLE
punctuation fixes, some new status lines, and fixed some wording (reupload of #124)

### DIFF
--- a/lua/homigrad/sh_status_messages.lua
+++ b/lua/homigrad/sh_status_messages.lua
@@ -40,6 +40,7 @@ local sharp_pain = {
 	"AAAaaAa",
 	"AaaAAaghf",
 	"aaAaaAaff",
+	"aaahhh",
 	"AAAaaGHHH",
 	"AAAaaAAHH",
 	"AAAaaAAAAAaGHHHH",
@@ -160,7 +161,7 @@ local dislocated_limb = {
 	"I have to get this bone back in.",
 	"No... I have to move it back in place.",
 	"It just hurts so much there. I might need a check up.",
-	"It's either I move it back into place or ask someone else to do it for me."
+	"My limb is out of place.",
 }
 
 local hungry_a_bit = {


### PR DESCRIPTION
Simple as that.
I'm an American Z-City player, so I wanted to fix up some of the punctuation in sh_status_messages.lua because some of the lines slightly didn't make sense or had a bit of typos.

I can probably do more if you guys want.

**reupload reason**
I apologize for making a whole new pull request. Some shit happened when merging my status messages with another fork I made, and it just went all downhill because it included changes that are meant just for my friends on our version of z-city.

it won't happen again.