### PR TITLE
mosin attachments fix

### DIFF
--- a/lua/weapons/weapon_mosin.lua
+++ b/lua/weapons/weapon_mosin.lua
@@ -79,7 +79,7 @@ SWEP.availableAttachments = {
 	sight = {
 		["mountType"] = "kar98mount",
 		["mountAngle"] = Angle(0,0,35),
-		["mount"] = Vector(5, 1.5, 0),
+		["mount"] = Vector(5, 1.5, 0.125),
 	},
 }
 


### PR DESCRIPTION
now attachments follow the weapon body in all animations; positions for all attachments are fixed
<img width="1556" height="619" alt="image" src="https://github.com/user-attachments/assets/5435c856-6d28-43d9-8ab7-14aea4369615" />
