### PR TITLE
Counter Strike now fully works + added few GUIs

### DIFF
--- a/gamemodes/zcity/gamemode/modes/tdm_cstrike/derma/cl_bomb_planted.lua
+++ b/gamemodes/zcity/gamemode/modes/tdm_cstrike/derma/cl_bomb_planted.lua
@@ -1,0 +1,57 @@
+local PANEL = {}
+local sw, sh = ScrW(), ScrH()
+local color_white = Color(255,255,255)
+local bg_color = Color(0,0,0,180)
+local accent_color = Color(92,92,92)
+
+net.Receive("bomb_planted", function()
+    vgui.Create("CS_BombPlanted")
+end)
+
+function PANEL:Init()
+
+
+    self:SetSize(sw * 0.4, sh * 0.08)
+    self:SetPos(sw * 0.5 - self:GetWide() * 0.5, -self:GetTall())
+
+    self:SetAlpha(0)
+
+    self.text = vgui.Create("DLabel", self)
+    self.text:Dock(FILL)
+    self.text:SetText("BOMB HAS BEEN PLANTED")
+    self.text:SetFont("ZB_InterfaceMediumLarge")
+    self.text:SetTextColor(color_white)
+    self.text:SetContentAlignment(5)
+
+    self:MoveTo(self:GetX(), sh * 0.08, 0.3, 0, -1)
+    self:AlphaTo(255, 0.3, 0)
+
+    timer.Simple(5, function()
+        if IsValid(self) then
+            self:Close()
+        end
+    end)
+end
+
+function PANEL:Paint(w, h)
+    surface.SetDrawColor(bg_color)
+    surface.DrawRect(0, 0, w, h)
+
+    surface.SetDrawColor(accent_color)
+    surface.DrawOutlinedRect(0, 0, w, h, 2)
+
+end
+
+function PANEL:Close()
+    self:MoveTo(self:GetX(), -self:GetTall(), 0.3, 0, -1)
+    self:AlphaTo(0, 0.3, 0)
+
+    timer.Simple(0.3, function()
+        if IsValid(self) then
+            self:Remove()
+        end
+    end)
+
+end
+
+vgui.Register("CS_BombPlanted", PANEL, "EditablePanel")

--- a/gamemodes/zcity/gamemode/modes/tdm_cstrike/derma/cl_intermission.lua
+++ b/gamemodes/zcity/gamemode/modes/tdm_cstrike/derma/cl_intermission.lua
@@ -2,10 +2,10 @@ local PANEL = {}
 local sw, sh = ScrW(), ScrH()    
 local color_white = Color(255,255,255)
 
-net.Receive("zb_cs_round_intermission", function()
+net.Receive("CS_Intermission", function()
 	plyteam = net.ReadBool()
 	rounds = net.ReadInt(6)
-	vgui.Create("zb_cs_round_intermission")
+	vgui.Create("CS_Intermission")
 end)
 
 function PANEL:Init()
@@ -95,5 +95,5 @@ function PANEL:Close()
 	})
 end
 
-vgui.Register("zb_cs_round_intermission", PANEL, "EditablePanel")
+vgui.Register("CS_Intermission", PANEL, "EditablePanel")
 

--- a/gamemodes/zcity/gamemode/modes/tdm_cstrike/derma/cl_killfeed.lua
+++ b/gamemodes/zcity/gamemode/modes/tdm_cstrike/derma/cl_killfeed.lua
@@ -1,0 +1,105 @@
+local PANEL = {}
+local sw, sh = ScrW(), ScrH()
+
+local color_white = Color(255,255,255)
+local ctcolor = Color(0,138,193)
+local tcolor = Color(164,118,0)
+local color_bg = Color(0,0,0,186)
+
+killfeedtbl = killfeedtbl or {}
+
+net.Receive("CS_Killfeed", function()
+    local plyteam = net.ReadBool()
+    local victimteam = net.ReadBool()
+    local killer = net.ReadString()
+    local victim = net.ReadString()
+
+    vgui.Create("CS_Killfeed"):Setup(plyteam, victimteam, killer, victim)
+end)
+
+function PANEL:Setup(plyteam, victimteam, killer, victim)
+    self.plyteam = plyteam
+    self.victimteam = victimteam
+    self.killer = killer
+    self.victim = victim
+end
+
+function PANEL:UpdateStack()
+    for i, panel in ipairs(killfeedtbl) do
+        if !IsValid(panel) then return end
+        panel:SetPos(sw * 0.78, sh * 0.02 + (i - 1) * (panel:GetTall() + 4))
+    end
+end
+
+function PANEL:Init()
+    self:SetSize(sw * 0.2, sh * 0.03)
+    self:SetAlpha(255)
+
+    table.insert(killfeedtbl, 1, self)
+    self:UpdateStack()
+
+    local margin = 10
+
+    self.leftName = vgui.Create("DLabel", self)
+    self.leftName:Dock(LEFT)
+    self.leftName:DockMargin(margin, 0, 0, 0)
+    self.leftName:SetWide(200)
+    self.leftName:SetFont("ZB_InterfaceSmall")
+    self.leftName:SetContentAlignment(4)
+
+    self.centerSkull = vgui.Create("DLabel", self)
+    self.centerSkull:Dock(FILL)
+    self.centerSkull:SetFont("ZB_InterfaceSmall")
+    self.centerSkull:SetContentAlignment(5)
+
+    self.rightName = vgui.Create("DLabel", self)
+    self.rightName:Dock(RIGHT)
+    self.rightName:DockMargin(0, 0, margin, 0)
+    self.rightName:SetWide(200)
+    self.rightName:SetFont("ZB_InterfaceSmall")
+    self.rightName:SetContentAlignment(6)
+
+    timer.Simple(0, function()
+        if !IsValid(self) then return end
+
+        self.leftName:SetText(self.killer)
+        self.leftName:SetTextColor(!self.plyteam and ctcolor or tcolor)
+
+        self.centerSkull:SetText("☠")
+        self.centerSkull:SetTextColor(color_white)
+
+        self.rightName:SetText(self.victim)
+        self.rightName:SetTextColor(!self.victimteam and ctcolor or tcolor)
+    end)
+	sound.PlayFile("homigrad/vgui/deathnotice.wav", "", function() end)
+
+    
+
+    timer.Simple(6, function()
+        if IsValid(self) then
+            self:Close()
+        end
+    end)
+end
+
+function PANEL:Paint(w, h)
+    surface.SetDrawColor(color_bg)
+    surface.DrawRect(0, 0, w, h)
+end
+
+function PANEL:Close()
+    self:AlphaTo(0, 0.3, 0, function()
+        if !IsValid(self) then return end
+
+        table.RemoveByValue(killfeedtbl, self)
+        self:Remove()
+
+        for _, panel in ipairs(killfeedtbl) do
+            if IsValid(panel) then
+                panel:UpdateStack()
+            end
+        end
+    end)
+end
+
+vgui.Register("CS_Killfeed", PANEL, "EditablePanel")

--- a/gamemodes/zcity/gamemode/modes/tdm_cstrike/derma/cl_roundover.lua
+++ b/gamemodes/zcity/gamemode/modes/tdm_cstrike/derma/cl_roundover.lua
@@ -1,0 +1,86 @@
+local PANEL = {}
+local sw, sh = ScrW(), ScrH()
+local color_white = Color(255,255,255)
+local ctcolor = Color(0,50,70)
+local tcolor = Color(70,50,0)
+local neutral_color = Color(65,65,65)
+local color_bg = Color(0,0,0,155)
+
+net.Receive("CS_Roundover", function()
+	winner = net.ReadBool()
+	winnerprt = net.ReadString()
+    vgui.Create("CS_Roundover")
+end)
+
+function PANEL:Init()
+    self:SetPos(sw * 0.35, sh * 0.15)
+    self:SetSize(sw * 0.3, sh * 0.09)
+
+    if IsValid(zb.CSIntermission) then
+        zb.CSIntermission:Remove()
+    end
+    zb.CSIntermission = self
+
+    self.appearAlpha = 255
+    self.appearProgress = 0
+    self.bClosing = false
+
+    self:CreateAnimation(1, {
+        index = 1,
+        target = {
+            appearAlpha = 0,
+            appearProgress = 1
+        },
+        easing = "linear",
+        bIgnoreConfig = true
+    })
+
+    self.text = vgui.Create("DLabel", self)
+    self.text:Dock(FILL)
+    self.text:SetText(winnerprt.." wins")
+    self.text:SetFont("ZB_InterfaceLarge")
+    self.text:SetTextColor(color_white)
+    self.text:SetContentAlignment(5)
+
+    timer.Simple(10, function()
+        if IsValid(self) then
+            self:Close()
+        end
+    end)
+end
+function PANEL:Paint(w, h)
+    surface.SetDrawColor((winnerprt=="Nobody" and neutral_color)or(winner and ctcolor or tcolor))
+    surface.DrawRect(0, 0, w, h)
+
+    surface.SetDrawColor((winnerprt=="Nobody" and neutral_color)or(winner and Color(0,137,191) or Color(184,132,0)))
+    surface.DrawOutlinedRect(0, 0, w, h, ScreenScale(1))
+
+	surface.SetDrawColor(color_bg)
+	surface.DrawRect(0, 0, w, h)
+
+    surface.SetDrawColor(255, 255, 255, self.appearAlpha * 4)
+    surface.DrawRect(0, 0, w, h)
+end
+
+function PANEL:Close()
+    if self.bClosing then return end
+    self.bClosing = true
+
+    self:CreateAnimation(1, {
+        index = 2,
+        target = {
+            appearAlpha = 255,
+            appearProgress = 0
+        },
+        easing = "linear",
+        bIgnoreConfig = true,
+        Think = function()
+            self:SetAlpha(255 * self.appearProgress / 2)
+        end,
+		OnComplete = function()
+			self:Remove()
+		end
+    })
+end
+
+vgui.Register("CS_Roundover", PANEL, "EditablePanel")

--- a/gamemodes/zcity/gamemode/modes/tdm_cstrike/sv_cstrike.lua
+++ b/gamemodes/zcity/gamemode/modes/tdm_cstrike/sv_cstrike.lua
@@ -418,6 +418,8 @@ end
 
 function MODE:RoundThink()
 end
+    
+local killfeedcv = CreateConVar("zb_killfeed",0,nil,"Killfeed for Counter-Strike",0,1)
 
 local sumamt = 0
 hook.Add("HarmDone", "CS_PlayerDeath", function(ply, victim, amt)
@@ -435,14 +437,13 @@ hook.Add("HarmDone", "CS_PlayerDeath", function(ply, victim, amt)
         victim:SetNWInt( "TDM_Money", math.max(victim:GetNWInt( "TDM_Money" ) - add, 0) )
     end
 
-    net.Start("CS_Killfeed")
-        net.WriteBool(ply:Team() == 0)
-        net.WriteBool(victim:Team() == 0)
-        net.WriteString(ply:Nick())
-        net.WriteString(victim:Nick())
-        net.Broadcast()
-    -- for i,v in player.Iterator() do
-    --     net.Send(v)
-    -- end
+    if killfeedcv:GetBool() then
+        net.Start("CS_Killfeed")
+            net.WriteBool(ply:Team() == 0)
+            net.WriteBool(victim:Team() == 0)
+            net.WriteString(ply:Nick())
+            net.WriteString(victim:Nick())
+            net.Broadcast()
+    end
 end)
 

--- a/gamemodes/zcity/gamemode/modes/tdm_cstrike/sv_cstrike.lua
+++ b/gamemodes/zcity/gamemode/modes/tdm_cstrike/sv_cstrike.lua
@@ -26,7 +26,9 @@ function MODE:ChanceFunction(info)
     return self.Chance
 end
 
-util.AddNetworkString("zb_cs_round_intermission")
+util.AddNetworkString("CS_Intermission")
+util.AddNetworkString("CS_Killfeed")
+util.AddNetworkString("CS_Roundover")
 
 function MODE:DontKillPlayer(ply)
     return zb.RoundsLeft and (zb.RoundsLeft != self.Rounds)
@@ -52,8 +54,6 @@ function MODE:RoundStartPost()
         NextRound(self.name)
     end
 end
-
-
 
 function MODE:Intermission()
 	game.CleanUpMap()
@@ -98,10 +98,10 @@ function MODE:Intermission()
         if self.GameStarted then
             ply:SetNWInt( "TDM_Money", self.StartMoney )
         end
-        net.Start("zb_cs_round_intermission")
-        net.WriteBool(ply:Team() == 0)
-        net.WriteInt(MODE.Rounds - zb.RoundsLeft or 0,6)
-        net.Send(ply)
+        net.Start("CS_Intermission")
+            net.WriteBool(ply:Team() == 0)
+            net.WriteInt(MODE.Rounds - zb.RoundsLeft or 0,6)
+            net.Send(ply)
     end
 
     if zb.rtype == "bomb" then
@@ -138,8 +138,6 @@ function MODE:Intermission()
         end)
     end
 
-    PrintMessage(HUD_PRINTTALK, "Round "..(self.Rounds - zb.RoundsLeft).." out of "..self.Rounds..".")
-
 	net.Start("tdm_start")
         net.WriteString(zb.rtype or "bomb")
         net.Broadcast()
@@ -174,6 +172,9 @@ COMMANDS.nextcsround = {
 	0
 }
 
+function MODE:CanLaunch()
+    return true
+end
 
 function MODE:EndRound()
     zb.RoundsLeft = zb.RoundsLeft or self.Rounds
@@ -187,6 +188,8 @@ function MODE:EndRound()
     local winner = 3
 
 	local tbl = zb:CheckAliveTeams(true)
+    local tcount = #tbl[0]
+    local ctcount = #tbl[1]
 
     if zb.rtype == "bomb" then
         if not IsValid(zb.bomb) then
@@ -200,19 +203,19 @@ function MODE:EndRound()
             winner = 1
         end
 
-        if IsValid(zb.bomb) and #tbl[0] == 0 and not zb.bomb.active then
+        if IsValid(zb.bomb) and tcount == 0 and not zb.bombexploded then
             winner = 1
         end
 
-        if IsValid(zb.bomb) and #tbl[1] == 0 and #tbl[0] > 0 then
+        if IsValid(zb.bomb) and ctcount == 0 and tcount > 0 then
             winner = 0
         end
 
-        if IsValid(zb.bomb) and #tbl[1] == 0 and #tbl[0] == 0 and zb.bomb.active then
+        if IsValid(zb.bomb) and ctcount == 0 and tcount == 0 and zb.bombexploded then
             winner = 0
         end
 
-        if IsValid(zb.bomb) and #tbl[0] == 0 and #tbl[1] == 0 and not zb.bomb.active then
+        if IsValid(zb.bomb) and tcount == 0 and ctcount == 0 and not zb.bomb:GetNWBool("active") then
             winner = 1
         end
     elseif zb.rtype == "hostage" then
@@ -244,7 +247,7 @@ function MODE:EndRound()
         if IsValid(zb.hostage) and zb.hostage.organism.alive then
             winner = 0
 
-            if #tbl[0] == 0 then
+            if tcount == 0 then
                 winner = 1
             end
         end
@@ -257,8 +260,6 @@ function MODE:EndRound()
 
     local winnerprt = (winner == 1 and "Counter-Terrorists") or (winner == 0 and "Terrorists") or "Nobody"
     
-    PrintMessage(HUD_PRINTTALK, winnerprt.." have won the round.")
-
 	for k,ply in player.Iterator() do
 		if ply:Team() == winner then
 			ply:GiveExp(math.random(15,30))
@@ -271,6 +272,12 @@ function MODE:EndRound()
             ply:SetNWInt( "TDM_Money", math.max(ply:GetNWInt( "TDM_Money" ) + 1750, 0) )
 		end
 	end
+    
+    net.Start("CS_Roundover")
+        net.WriteBool(winner)
+        net.WriteString(winnerprt)
+        net.Broadcast()
+    winreason = 0
 
 	local winsTeam0 = zb.Winners[0] or 0
 	local winsTeam1 = zb.Winners[1] or 0
@@ -351,8 +358,18 @@ function MODE:ShouldRoundEnd()
     if zb.ROUND_START + 5 > CurTime() then return false end
 
 	local tbl = zb:CheckAliveTeams(true)
+    local tcount = #tbl[0]
+    local ctcount = #tbl[1]
     
     if zb.rtype == "bomb" then
+        if IsValid(zb.bomb) and zb.bomb:GetNWBool("active") and ctcount == 0 then
+            return true
+        end
+
+        if IsValid(zb.bomb) and zb.bomb:GetNWBool("active") then
+            return false    
+        end
+
         if zb.bombexploded then
             return true
         end
@@ -361,19 +378,15 @@ function MODE:ShouldRoundEnd()
             return true
         end
 
-        if #tbl[0] == 0 and not zb.bomb.active then
+        if tcount == 0 and not zb.bombexploded then
             return true
         end
 
-        if #tbl[1] == 0 and #tbl[0] > 0 then
+        if ctcount == 0 and tcount > 0 then
             return true
         end
 
-        if #tbl[1] == 0 and #tbl[0] == 0 and zb.bomb.active then
-            return true
-        end
-        
-        if #tbl[0] == 0 and #tbl[1] == 0 and not zb.bomb.active then
+        if ctcount == 0 and tcount == 0 and zb.bombexploded then
             return true
         end
     elseif zb.rtype == "hostage" then
@@ -381,11 +394,23 @@ function MODE:ShouldRoundEnd()
             return true
         end
 
-        if #tbl[0] == 0 or #tbl[1] == 0 or not zb.hostage.organism.alive then
+        if tcount == 0 or ctcount == 0 or not zb.hostage.organism.alive then
             return true
         end
         
         if zb.hostage.organism.alive and HostageInZone(zb.hostage:GetPos()) then
+            return true
+        end
+    else
+        if tcount == 0 and ctcount == 0 then
+            return true
+        end
+
+        if tcount == 0 and ctcount > 0 then
+            return true
+        end
+
+        if ctcount == 0 and tcount > 0 then
             return true
         end
     end
@@ -394,20 +419,30 @@ end
 function MODE:RoundThink()
 end
 
-hook.Add("HarmDone", "MoneyGive", function(ply, victim, amt) 
+local sumamt = 0
+hook.Add("HarmDone", "CS_PlayerDeath", function(ply, victim, amt)
+    -- not sure how this works. even PlayerDeath hook returns same player as a victim and attacker for some reason. 
     if not CurrentRound().KillMoney then return end
-    if not victim:IsPlayer() then return end
-    if ply == victim then return end
-    
+    sumamt = sumamt + amt
+    if sumamt < 1 and victim:Alive() then return end
+    sumamt = 0 
     local add = amt * MODE.KillMoney * (ply:Team() == victim:Team() and -1 or 1)
-    
     add = math.Round(add,0)
-
     --print(add,ply,ply:GetNWInt("TDM_Money"),victim)
-
     ply:SetNWInt( "TDM_Money", math.max(ply:GetNWInt( "TDM_Money" ) + add, 0) )
-
+    
     if (ply:Team() == victim:Team()) and add <= 0 then
         victim:SetNWInt( "TDM_Money", math.max(victim:GetNWInt( "TDM_Money" ) - add, 0) )
     end
+
+    net.Start("CS_Killfeed")
+        net.WriteBool(ply:Team() == 0)
+        net.WriteBool(victim:Team() == 0)
+        net.WriteString(ply:Nick())
+        net.WriteString(victim:Nick())
+        net.Broadcast()
+    -- for i,v in player.Iterator() do
+    --     net.Send(v)
+    -- end
 end)
+

--- a/lua/entities/bomb/init.lua
+++ b/lua/entities/bomb/init.lua
@@ -25,6 +25,7 @@ end
 
 util.AddNetworkString("bomb_look")
 util.AddNetworkString("bomb_enter")
+util.AddNetworkString("bomb_planted")
 
 function BombInSite(pos, site)
 	local pts = zb.GetMapPoints( "BOMB_ZONE_"..(site == 1 and "A" or "B") )
@@ -95,6 +96,7 @@ function ENT:DisableBomb()
 	self:SetNetVar("timer", nil)
 	self.addtime = activetime
 	self.active = nil
+	self:SetNWBool("active",false)
 
 	local phys = self:GetPhysicsObject()
 	if IsValid(phys) then
@@ -107,6 +109,11 @@ local offsetAng = Angle(-90,0,180)
 function ENT:ActivateBomb()
 	self:SetNetVar("timer", CurTime() + self.ExplodeTime - (self.addtime or 0))
 	self.active = true
+	self:SetNWBool("active",true)
+	print(self:GetNWBool("active"))
+
+	net.Start("bomb_planted")
+		net.Broadcast()
 
 	if self.tbl and not self.activatedonce then
 		local siteName
@@ -115,9 +122,9 @@ function ENT:ActivateBomb()
 		elseif BombInSite(self:GetPos(), 2) then
 			siteName = "B"
 		end
-		PrintMessage(HUD_PRINTTALK, "Bomb has been planted"
-			..(siteName and (" on site "..siteName) or "")
-			..".")
+		-- PrintMessage(HUD_PRINTTALK, "Bomb has been planted"
+		-- 	..(siteName and (" on site "..siteName) or "")
+		-- 	..".")
 		
 		hg.UpdateRoundTime(zb.ROUND_TIME + self.ExplodeTime + 1)
 	end
@@ -176,6 +183,7 @@ function ENT:Think()
 			zb.bombexploded = true
 			util.ScreenShake( selfPos, 95, 500, 4, 1000 )
 			hg.PropExplosion(self, "Fire", 300, 100)
+			zb.bomb:SetNWBool("active",false)
 		end
 
 		--;; WHAT THE FAK YUUUUUUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAH

--- a/lua/entities/bomb/init.lua
+++ b/lua/entities/bomb/init.lua
@@ -110,7 +110,7 @@ function ENT:ActivateBomb()
 	self:SetNetVar("timer", CurTime() + self.ExplodeTime - (self.addtime or 0))
 	self.active = true
 	self:SetNWBool("active",true)
-	print(self:GetNWBool("active"))
+	--print(self:GetNWBool("active"))
 
 	net.Start("bomb_planted")
 		net.Broadcast()


### PR DESCRIPTION
GUIs:
-- Roundover screen
-- Killfeed
-- Bomb planted screen
-- Money

now no need to skip round after warm-up phase ended
a few round ending logic changes (if no ct alive and there's bomb -> t wins and if bomb active and no t alive then ct need to disarm bomb)
CS is now in a queue
updated money adding logic. no longer you can get infinite money when damaging legs non lethally, get money only when person is killed.

добавьте правила написания ПРов, а то я понятия не имею на каком мне языке даже это писать и что вписывать сюдой

tested on 2560x1440 and 1920x1080.
<img width="205" height="160" alt="Discord_19QynyE3xx" src="https://github.com/user-attachments/assets/70873703-b1b3-482f-bf4f-f5ae490c38fe" />
<img width="144" height="90" alt="gmod_6dyJeHkpJ1" src="https://github.com/user-attachments/assets/3f7636a2-db44-4687-8318-43008d9694e9" />
<img width="921" height="242" alt="Discord_HbGZZ0wWna" src="https://github.com/user-attachments/assets/c1eba317-22dc-4cde-9e85-2065ddc42da1" />
<img width="565" height="71" alt="Discord_xLytfUo4Ss" src="https://github.com/user-attachments/assets/6b8a355e-b744-4c98-a4db-9a8b0449c6cf" />
<img width="1205" height="238" alt="Discord_1Hh81Zjuj1" src="https://github.com/user-attachments/assets/7326c088-c6b7-4757-adcf-816ea04f1e30" />
<img width="576" height="87" alt="Discord_qTd47Hpv63" src="https://github.com/user-attachments/assets/74c77b7c-710b-4678-987d-3f92daa3767e" />
<img width="549" height="62" alt="image" src="https://github.com/user-attachments/assets/868a75cd-7421-4a31-8d75-fbbefe17f04d" />
![cool-skeleton-on-a-motorcycle-cool (1)](https://github.com/user-attachments/assets/53c8ecd6-fcb4-4cc2-9b95-54444720ab9f)
