### PR TITLE
Fix tick calculation in cl_init.lua

### DIFF
--- a/gamemodes/zcity/gamemode/cl_init.lua
+++ b/gamemodes/zcity/gamemode/cl_init.lua
@@ -620,7 +620,7 @@ function GM:ScoreboardShow()
 		local lengthX, lengthY = surface.GetTextSize("Spectators:")
 		surface.SetTextPos(w * 0.75 - lengthX/2,ScreenScale(25))
 		surface.DrawText("Spectators:")
-		tick = math.Round(1 / engine.ServerFrameTime()
+		tick = math.Round(1 / engine.ServerFrameTime())
 		local txt = "SV Tick: " .. tick
 		local lengthX, lengthY = surface.GetTextSize(txt)
 		surface.SetTextPos(w * 0.5 - lengthX/2,ScreenScale(25))


### PR DESCRIPTION
Currently it shows a inaccurate value as the lerp isn't used right, the lerp isn't needed anyways.