### PR TITLE
Defense mode: revamp spawns, waves, and votes | Error fixes

### DIFF
--- a/gamemodes/zcity/gamemode/modes/defense/cl_defense.lua
+++ b/gamemodes/zcity/gamemode/modes/defense/cl_defense.lua
@@ -641,7 +641,7 @@ local function CreateVoteMenu()
         button.SelectedFrac = 0
         
   
-        local isDisabled = (index == 3) 
+        local isDisabled = false
         
         button.Paint = function(self, w, h)
             local baseColor = modeDescriptions[index].color
@@ -869,9 +869,6 @@ net.Receive("defense_submit_vote", function(len, ply)
     
     local vote = net.ReadInt(4)
     if vote < 1 or vote > 3 then return end
-    
-
-    if vote == 3 then return end
     
     local MODE = CurrentRound()
     if not MODE or MODE.name ~= "defense" or not MODE.VoteInProgress then return end

--- a/gamemodes/zcity/gamemode/modes/defense/sv_defense.lua
+++ b/gamemodes/zcity/gamemode/modes/defense/sv_defense.lua
@@ -19,6 +19,30 @@ MODE.LootSpawn = true
 MODE.ForBigMaps = true
 MODE.Chance = 0.02
 
+local defenseDefaultPlayerSpawns = {
+    "info_player_deathmatch", "info_player_combine", "info_player_rebel",
+    "info_player_counterterrorist", "info_player_terrorist", "info_player_axis",
+    "info_player_allies", "gmod_player_start", "info_player_teamspawn",
+    "ins_spawnpoint", "aoc_spawnpoint", "dys_spawn_point", "info_player_pirate",
+    "info_player_viking", "info_player_knight", "diprip_start_team_blue", "diprip_start_team_red",
+    "info_player_red", "info_player_blue", "info_player_coop", "info_player_human", "info_player_zombie",
+    "info_player_zombiemaster", "info_player_fof", "info_player_desperado", "info_player_vigilante", "info_survivor_rescue"
+}
+
+local defensePlayerSpawnHullMins = Vector(-16, -16, 0)
+local defensePlayerSpawnHullMaxs = Vector(16, 16, 72)
+local defensePlayerSpawnOffsets = {
+    vector_origin,
+    Vector(24, 0, 0),
+    Vector(-24, 0, 0),
+    Vector(0, 24, 0),
+    Vector(0, -24, 0),
+    Vector(24, 24, 0),
+    Vector(-24, 24, 0),
+    Vector(24, -24, 0),
+    Vector(-24, -24, 0)
+}
+
 
 
 util.AddNetworkString("defense_start_vote")
@@ -92,6 +116,7 @@ end
 
 function MODE:EndWave()
     self.WaveActive = false
+    self.WaveSpawnInProgress = false
     self:ClearAllTimers()
 
     net.Start("StopWaveMusic")
@@ -135,11 +160,90 @@ function MODE:EndWave()
     end
 end
 
+function MODE:GetGroundedPlayerSpawn(spawnPoint)
+    if not spawnPoint or not spawnPoint.pos then
+        return nil
+    end
+
+    local basePos = spawnPoint.pos
+    local groundTrace = util.TraceLine({
+        start = basePos + Vector(0, 0, 64),
+        endpos = basePos - Vector(0, 0, 512),
+        mask = MASK_SOLID_BRUSHONLY
+    })
+
+    if groundTrace.Hit and not groundTrace.HitSky then
+        basePos = groundTrace.HitPos + Vector(0, 0, 4)
+    end
+
+    for _, offset in ipairs(defensePlayerSpawnOffsets) do
+        local candidate = basePos + offset
+        local hullTrace = util.TraceHull({
+            start = candidate,
+            endpos = candidate,
+            mins = defensePlayerSpawnHullMins,
+            maxs = defensePlayerSpawnHullMaxs,
+            filter = player.GetAll(),
+            mask = MASK_PLAYERSOLID
+        })
+
+        if not hullTrace.Hit then
+            return candidate
+        end
+    end
+
+    return basePos
+end
+
+function MODE:GetUsualPlayerSpawnPoints()
+    local points = zb.GetMapPoints("Spawnpoint") or {}
+
+    if #points > 0 then
+        local newPoints = {}
+        table.CopyFromTo(points, newPoints)
+        return newPoints
+    end
+
+    local spawnPoints = {}
+
+    for _, ent in ipairs(ents.FindByClass("info_player_start")) do
+        spawnPoints[#spawnPoints + 1] = {
+            pos = ent:GetPos(),
+            ang = ent:GetAngles()
+        }
+    end
+
+    for _, className in ipairs(defenseDefaultPlayerSpawns) do
+        for _, ent in ipairs(ents.FindByClass(className)) do
+            spawnPoints[#spawnPoints + 1] = {
+                pos = ent:GetPos(),
+                ang = ent:GetAngles()
+            }
+        end
+    end
+
+    return spawnPoints
+end
+
+function MODE:GetDefenseAnchorPoints()
+    local npcSpawnPoints = zb.GetMapPoints("NPC_DEFENSE_SPAWN") or {}
+    if #npcSpawnPoints > 0 then
+        return npcSpawnPoints
+    end
+
+    local defensePoints = zb.GetMapPoints("DEFENSE_POINT") or {}
+    if #defensePoints > 0 then
+        return defensePoints
+    end
+
+    return self:GetUsualPlayerSpawnPoints()
+end
+
 function MODE:CanLaunch()
-	local points = zb.GetMapPoints( "PLY_DEFENSE_SPAWN" )
-	local points2 = zb.GetMapPoints( "NPC_DEFENSE_SPAWN" )
+    local points = self:GetUsualPlayerSpawnPoints()
+    local navAreas = navmesh.GetAllNavAreas() or {}
     
-    return false--(#points > 0) and (#points2 > 0)
+    return (#points > 0) and (#navAreas > 0)
 end
 
 function MODE:Intermission()
@@ -151,7 +255,7 @@ function MODE:Intermission()
     self:ClearAllTimers() 
     game.CleanUpMap()
 
-    self.SpawnPoints = zb.GetMapPoints("PLY_DEFENSE_SPAWN")
+    self.SpawnPoints = self:GetUsualPlayerSpawnPoints()
     if not self.SpawnPoints then
         self.SpawnPoints = {}
     end
@@ -210,16 +314,12 @@ function MODE:EndVoting()
     local selectedModes = {}
     
     for mode, votes in pairs(self.VoteResults) do
-        if mode == 3 then continue end
-        
         if votes > highestVotes then
             highestVotes = votes
         end
     end
     
     for mode, votes in pairs(self.VoteResults) do
-        if mode == 3 then continue end
-        
         if votes == highestVotes then
             table.insert(selectedModes, mode)
         end
@@ -231,10 +331,6 @@ function MODE:EndVoting()
     end
     
 
-    if selectedMode == 3 then
-        selectedMode = 1 
-    end
-    
     if selectedMode == 1 then
         self.CurrentSubMode = "STANDARD"
         self.TotalWaves = 6
@@ -242,7 +338,7 @@ function MODE:EndVoting()
         self.CurrentSubMode = "EXTENDED"
         self.TotalWaves = 12
     elseif selectedMode == 3 then
-        self.CurrentSubMode = "STANDARD" 
+        self.CurrentSubMode = "ZOMBIE"
         self.TotalWaves = 6
     end
     
@@ -445,7 +541,7 @@ function MODE:RoundThink()
         end
         
 
-        if self.NPCCount <= 0 and self:IsWaveActive() then
+        if self.NPCCount <= 0 and self:IsWaveActive() and not self.WaveSpawnInProgress then
             print("[DEFENSE] Wave Ended: No NPCs remaining!")
             self:EndWave()
             
@@ -524,8 +620,6 @@ net.Receive("defense_submit_vote", function(len, ply)
     local vote = net.ReadInt(4)
     if vote < 1 or vote > 3 then return end
 
-    if vote == 3 then return end
-    
     local MODE = CurrentRound()
     if not MODE or MODE.name ~= "defense" or not MODE.VoteInProgress then return end
     
@@ -558,8 +652,6 @@ net.Receive("defense_change_vote", function(len, ply)
     local newVote = net.ReadInt(4)
     
     if newVote < 1 or newVote > 3 then return end
-    
-    if newVote == 3 then return end
     
     local MODE = CurrentRound()
     if not MODE or MODE.name ~= "defense" or not MODE.VoteInProgress then return end

--- a/gamemodes/zcity/gamemode/modes/defense/sv_defense_config.lua
+++ b/gamemodes/zcity/gamemode/modes/defense/sv_defense_config.lua
@@ -171,90 +171,92 @@ DEFENSE_WAVE_DEFINITIONS = {
     EXTENDED = {
         [1] = {
             {type = "npc_metropolice", weapon = "weapon_hk_usp", health = 90, count = 4, default_weapon = false},
-           {type = "zb_myt_cmb_shield", weapon = "weapon_hk_usp", health = 95, count = 2, default_weapon = true}
+            {type = "npc_manhack", count = 3, health = 35}
         },
         [2] = {
-            {type = "zb_metropolice_elite", weapon = "weapon_deagle", health = 100, count = 4, default_weapon = false},
-            {type = "zb_myt_cmb_shield", weapon = "weapon_mp7", health = 100, count = 4, default_weapon = false}
+            {type = "npc_metropolice", weapon = "weapon_mp7", health = 90, count = 4, default_weapon = false},
+            {type = "npc_combine_s", weapon = "weapon_mp7", health = 110, count = 4, default_weapon = false}
         },
         [3] = {
-            {type = "zb_metropolice_elite", weapon = "weapon_mp7", health = 120, count = 10, default_weapon = false},
+            {type = "npc_combine_s", weapon = "weapon_mp7", health = 120, count = 8, default_weapon = false},
+            {type = "npc_manhack", count = 4, health = 35}
         },
         [4] = {
-            {type = "zb_metropolice_elite", weapon = "weapon_deagle", health = 120, count = 3, default_weapon = false},
             {type = "npc_combine_s", weapon = "weapon_mp7", health = 120, count = 5, default_weapon = false},
-            {type = "npc_manhack", count = 4}
+            {type = "npc_combine_s", weapon = "weapon_spas12", health = 120, count = 3, default_weapon = false},
+            {type = "npc_clawscanner", count = 2, health = 50}
         },
         [5] = {
-            {type = "npc_combine_s", weapon = "weapon_mp7", health = 120, count = 8, default_weapon = false},
-            {type = "npc_manhack", count = 2}
+            {type = "npc_combine_s", weapon = "weapon_osipr", health = 130, count = 6, default_weapon = false},
+            {type = "npc_combine_s", weapon = "weapon_spas12", health = 130, count = 4, default_weapon = false},
+            {type = "npc_manhack", count = 3, health = 35}
         },
         [6] = {
-            {type = "beta_unit_synth_soldier", weapon = "", health = 1000, count = 1, boss = true},
-            {type = "npc_combine_s", weapon = "weapon_osipr", health = 100, count = 7, default_weapon = false},
-            {type = "ej_combine_sniper", count = 2, weapon = "weapon_combinesniper", relationship = {class = "npc_combine_s", disposition = D_LI}}
+            {type = "npc_hunter", weapon = "", health = 900, count = 1, boss = true},
+            {type = "npc_combine_s", weapon = "weapon_osipr", health = 130, count = 6, default_weapon = false},
+            {type = "npc_turret_floor", count = 1, no_target = true, health = 220}
         },
         [7] = {
-            {type = "npc_combine_s", weapon = "weapon_osipr", health = 110, count = 5, default_weapon = false},
-            {type = "npc_combine_s", weapon = "weapon_spas12", health = 110, count = 3, default_weapon = false},
-            {type = "zb_myt_cmb_wallham", count = 2, health = 200, weapon = "weapon_m249", default_weapon = true}
+            {type = "npc_combine_s", weapon = "weapon_osipr", health = 140, count = 6, model = "models/Combine_Super_Soldier.mdl", default_weapon = false},
+            {type = "npc_combine_s", weapon = "weapon_spas12", health = 140, count = 4, model = "models/Combine_Super_Soldier.mdl", default_weapon = false},
+            {type = "npc_manhack", count = 4, health = 35}
         },
         [8] = {
-            {type = "npc_combine_s", weapon = "weapon_osipr", health = 110, count = 5, default_weapon = false},
-            {type = "npc_combine_s", weapon = "weapon_spas12", health = 110, count = 5, default_weapon = false},
-            {type = "zb_manhack", count = 2}
+            {type = "npc_combine_s", weapon = "weapon_osipr", health = 140, count = 6, default_weapon = false},
+            {type = "npc_combine_s", weapon = "weapon_spas12", health = 140, count = 4, default_weapon = false},
+            {type = "npc_turret_floor", count = 2, no_target = true, health = 220}
         },
         [9] = {
-            {type = "beta_unit_combine_sniper", weapon = "weapon_combinesniper", health = 130, count = 3   },
-            {type = "zb_myt_cmb_wallham", weapon = "weapon_osipr", health = 150, count = 5, default_weapon = false},
-            {type = "zb_myt_cmb_pain", weapon = "weapon_mp7", health = 130, count = 3, default_weapon = false}
+            {type = "npc_hunter", weapon = "", health = 700, count = 2},
+            {type = "npc_combine_s", weapon = "weapon_osipr", health = 150, count = 6, model = "models/Combine_Super_Soldier.mdl", default_weapon = false},
+            {type = "npc_clawscanner", count = 3, health = 50}
         },
         [10] = {
-            {type = "beta_unit_synth_brown", weapon = "weapon_osipr", health = 90, count = 5, default_weapon = true},
-            {type = "beta_unit_synth_brown", weapon = "weapon_osipr", health = 90, count = 5, default_weapon = true}
+            {type = "npc_combine_s", weapon = "weapon_osipr", health = 155, count = 8, model = "models/Combine_Super_Soldier.mdl", default_weapon = false},
+            {type = "npc_manhack", count = 5, health = 35},
+            {type = "npc_turret_floor", count = 1, no_target = true, health = 220}
         },
         [11] = {
-            {type = "beta_unit_combine_assassin", weapon = "weapon_deagle", health = 100, count = 3, default_weapon = true},
-            {type = "zb_myt_cmb_wallham", weapon = "weapon_osipr", health = 200, count = 9, default_weapon = false}
+            {type = "npc_hunter", weapon = "", health = 800, count = 3},
+            {type = "npc_combine_s", weapon = "weapon_osipr", health = 160, count = 8, model = "models/Combine_Super_Soldier.mdl", default_weapon = false}
         },
         [12] = {
-            {type = "zb_combine_juggernaut", weapon = "weapon_m60", health = 2500, count = 1, boss = true},
-            {type = "beta_unit_synth_brown", weapon = "weapon_osipr", health = 90, count = 10, weapondefault = true},
-            {type = "beta_unit_combine_sniper", weapon = "weapon_m98b", health = 100, count = 4,
-             default_weapon = false}
+            {type = "npc_hunter", weapon = "", health = 1200, count = 2, boss = true},
+            {type = "npc_combine_s", weapon = "weapon_osipr", health = 170, count = 10, model = "models/Combine_Super_Soldier.mdl", default_weapon = false},
+            {type = "npc_turret_floor", count = 2, no_target = true, health = 220}
         }
     },
     
     ZOMBIE = {
         [1] = {
-            {type = "sent_vj_l4d_cominf", weapon = "", health = 100, count = 8, aggressive = true},
-            {type = "sent_vj_l4d_cominf", weapon = "", health = 150, count = 5}
+            {type = "npc_zombie", weapon = "", health = 120, count = 8, aggressive = true},
+            {type = "npc_headcrab", weapon = "", health = 25, count = 6}
         },
         [2] = {
-            {type = "sent_vj_l4d_cominf", weapon = "", health = 125, count = 6},
-            {type = "sent_vj_l4d_cominf", weapon = "", health = 175, count = 6},
-            {type = "sent_vj_l4d_cominf", weapon = "", health = 200, count = 4}
+            {type = "npc_zombie", weapon = "", health = 130, count = 8},
+            {type = "npc_fastzombie", weapon = "", health = 95, count = 5},
+            {type = "npc_headcrab_fast", weapon = "", health = 20, count = 6}
         },
         [3] = {
-            {type = "sent_vj_l4d_cominf", weapon = "", health = 200, count = 5},
-            {type = "npc_vj_l4d_com_m_riot", weapon = "", health = 225, count = 5},
-            {type = "sent_vj_l4d_cominf", weapon = "", health = 180, count = 7}
+            {type = "npc_zombie", weapon = "", health = 150, count = 8},
+            {type = "npc_fastzombie", weapon = "", health = 105, count = 6},
+            {type = "npc_zombine", weapon = "", health = 170, count = 3}
         },
         [4] = {
-            {type = "sent_vj_l4d_cominf", weapon = "", health = 250, count = 6},
-            {type = "sent_vj_l4d_cominf", weapon = "", health = 200, count = 6},
-            {type = "sent_vj_l4d_cominf", weapon = "", health = 225, count = 8}
+            {type = "npc_poisonzombie", weapon = "", health = 280, count = 2},
+            {type = "npc_fastzombie", weapon = "", health = 115, count = 7},
+            {type = "npc_headcrab_poison", weapon = "", health = 35, count = 6}
         },
         [5] = {
-            {type = "sent_vj_l4d_cominf", weapon = "", health = 250, count = 6},
-            {type = "sent_vj_l4d_cominf", weapon = "", health = 275, count = 6},
-            {type = "sent_vj_l4d_cominf", weapon = "", health = 400, count = 8, aggressive = true}
+            {type = "npc_poisonzombie", weapon = "", health = 320, count = 3},
+            {type = "npc_fastzombie", weapon = "", health = 125, count = 8},
+            {type = "npc_zombine", weapon = "", health = 190, count = 5, aggressive = true}
         },
         [6] = {
-            {type = "sent_vj_l4d_cominf", weapon = "", health = 300, count = 8},
-            {type = "npc_vj_l4d_com_m_mudmen", weapon = "", health = 500, count = 8},
-            {type = "npc_vj_l4d_com_m_mudmen", weapon = "", health = 450, count = 7, aggressive = true},
-            {type = "npc_vj_l4d_com_m_mudmen", weapon = "", health = 1000, count = 2, aggressive = true}
+            {type = "npc_poisonzombie", weapon = "", health = 500, count = 4, boss = true},
+            {type = "npc_fastzombie", weapon = "", health = 135, count = 10},
+            {type = "npc_zombine", weapon = "", health = 220, count = 6, aggressive = true},
+            {type = "npc_headcrab_black", weapon = "", health = 35, count = 6}
         }
     }
 }

--- a/gamemodes/zcity/gamemode/modes/defense/sv_defense_roles.lua
+++ b/gamemodes/zcity/gamemode/modes/defense/sv_defense_roles.lua
@@ -180,15 +180,27 @@ end
 
 function MODE:GetPlySpawn(ply)
     if self.SpawnPoints and #self.SpawnPoints > 0 then
-        ply:SetPos(self.SpawnPoints[#self.SpawnPoints].pos)
-        if #self.SpawnPoints > 1 then 
-            table.remove(self.SpawnPoints)
+        local spawnIndex = #self.SpawnPoints
+        local spawnPoint = self.SpawnPoints[spawnIndex]
+        local spawnPos = self.GetGroundedPlayerSpawn and self:GetGroundedPlayerSpawn(spawnPoint) or spawnPoint.pos
+
+        ply:SetPos(spawnPos)
+        ply:SetLocalVelocity(vector_origin)
+
+        if spawnPoint.ang then
+            ply:SetEyeAngles(Angle(0, spawnPoint.ang.y, 0))
         end
+
+        if #self.SpawnPoints > 1 then 
+            table.remove(self.SpawnPoints, spawnIndex)
+        end
+
+        return spawnPos
     end
 end
 
 function MODE:GiveEquipment()
-    self.SpawnPoints = zb.GetMapPoints("PLY_DEFENSE_SPAWN")
+    self.SpawnPoints = self.GetUsualPlayerSpawnPoints and self:GetUsualPlayerSpawnPoints() or {}
     if not self.SpawnPoints then
         self.SpawnPoints = {}
     end

--- a/gamemodes/zcity/gamemode/modes/defense/sv_defense_support.lua
+++ b/gamemodes/zcity/gamemode/modes/defense/sv_defense_support.lua
@@ -367,7 +367,7 @@ local function RespawnDeadPlayers(requester)
     end
     
 
-    local spawnPoints = zb.GetMapPoints("PLY_DEFENSE_SPAWN")
+    local spawnPoints = MODE.GetUsualPlayerSpawnPoints and MODE:GetUsualPlayerSpawnPoints() or {}
     if not spawnPoints or #spawnPoints == 0 then
         if IsValid(requester) then
             requester:ChatPrint("No spawn points available!")
@@ -443,12 +443,18 @@ local function RespawnDeadPlayers(requester)
         if IsValid(ply) and not ply:Alive() and ply:Team() != TEAM_SPECTATOR then
 
             local spawnPoint = spawnPoints[math.random(#spawnPoints)]
+            local spawnPos = MODE.GetGroundedPlayerSpawn and MODE:GetGroundedPlayerSpawn(spawnPoint) or spawnPoint.pos
             
 
             ply:Spawn()
             
 
-            ply:SetPos(spawnPoint.pos)
+            ply:SetPos(spawnPos)
+            ply:SetLocalVelocity(vector_origin)
+
+            if spawnPoint.ang then
+                ply:SetEyeAngles(Angle(0, spawnPoint.ang.y, 0))
+            end
             
 
             ply:SetSuppressPickupNotices(true)

--- a/gamemodes/zcity/gamemode/modes/defense/sv_defense_waves.lua
+++ b/gamemodes/zcity/gamemode/modes/defense/sv_defense_waves.lua
@@ -1,5 +1,9 @@
 local MODE = MODE
 
+local defenseSpawnMinPlayerDistanceSqr = 550 * 550
+local defenseSpawnVisibilityDot = 0.2
+local defenseSpawnStepDelay = 0.8
+
 
  local _OrigSpawn = SpawnZBaseNPC
  function SpawnZBaseNPC(ply, npcClass, pos, weaponClass)
@@ -26,6 +30,42 @@ local MODE = MODE
 
     return npc
  end
+
+function MODE:IsSpawnVisibleToAnyPlayer(spawnPos)
+    local targetPos = spawnPos + Vector(0, 0, 48)
+
+    for _, ply in player.Iterator() do
+        if not (IsValid(ply) and ply:Alive() and ply:Team() ~= TEAM_SPECTATOR) then
+            continue
+        end
+
+        local eyePos = ply:EyePos()
+        local toSpawn = targetPos - eyePos
+        local distSqr = toSpawn:LengthSqr()
+
+        if distSqr <= defenseSpawnMinPlayerDistanceSqr then
+            return true
+        end
+
+        local direction = toSpawn:GetNormalized()
+        if ply:EyeAngles():Forward():Dot(direction) < defenseSpawnVisibilityDot then
+            continue
+        end
+
+        local trace = util.TraceLine({
+            start = eyePos,
+            endpos = targetPos,
+            mask = MASK_BLOCKLOS,
+            filter = ply
+        })
+
+        if not trace.Hit or trace.Fraction >= 0.98 then
+            return true
+        end
+    end
+
+    return false
+end
 
 function MODE:FindValidSpawnPoint(center, radius)
     local attempts = 10
@@ -60,10 +100,79 @@ function MODE:FindValidSpawnPoint(center, radius)
 
         if ceilingTrace.Hit then continue end
 
+        if self:IsSpawnVisibleToAnyPlayer(spawnPos) then continue end
+
         return spawnPos
     end
 
     return nil 
+end
+
+function MODE:IsValidNavMeshSpawn(spawnPos)
+    if not spawnPos then
+        return false
+    end
+
+    if bit.band(util.PointContents(spawnPos), CONTENTS_WATER) == CONTENTS_WATER then
+        return false
+    end
+
+    local hullTrace = util.TraceHull({
+        start = spawnPos,
+        endpos = spawnPos,
+        mins = Vector(-16, -16, 0),
+        maxs = Vector(16, 16, 72),
+        mask = MASK_PLAYERSOLID
+    })
+
+    if hullTrace.Hit then
+        return false
+    end
+
+    if self:IsSpawnVisibleToAnyPlayer(spawnPos) then
+        return false
+    end
+
+    return true
+end
+
+function MODE:FindNavMeshSpawnPoint(center, minRadius, maxRadius)
+    local areas = navmesh.GetAllNavAreas() or {}
+    if #areas == 0 then
+        return nil
+    end
+
+    minRadius = minRadius or 0
+    maxRadius = maxRadius or 4000
+
+    local minRadiusSqr = minRadius * minRadius
+    local maxRadiusSqr = maxRadius * maxRadius
+    local candidates = {}
+
+    for _, area in ipairs(areas) do
+        if area:IsUnderwater() then
+            continue
+        end
+
+        local spawnPos = area:GetCenter() + Vector(0, 0, 10)
+
+        if center then
+            local distSqr = center:DistToSqr(spawnPos)
+            if distSqr < minRadiusSqr or distSqr > maxRadiusSqr then
+                continue
+            end
+        end
+
+        if self:IsValidNavMeshSpawn(spawnPos) then
+            candidates[#candidates + 1] = spawnPos
+        end
+    end
+
+    if #candidates == 0 then
+        return nil
+    end
+
+    return candidates[math.random(#candidates)]
 end
 
 
@@ -130,7 +239,7 @@ end
 
 
 function MODE:SpawnWave()
-    local spawnPoints = zb.GetMapPoints("NPC_DEFENSE_SPAWN")
+    local spawnPoints = self.GetDefenseAnchorPoints and self:GetDefenseAnchorPoints() or {}
     if not spawnPoints or #spawnPoints == 0 then
         return
     end
@@ -142,10 +251,13 @@ function MODE:SpawnWave()
     
     self.NPCCount = 0
     self.DefenseWaveEntities = {}
+    self.WaveSpawnInProgress = true
     
     local currentWave = waveDefinitions[self.Wave]
-    local spawnRadius = 70
-    local spawnedNPCs = {}
+    local spawnRadius = 2500
+    local spawnQueue = {}
+    self.SpawnBatchID = (self.SpawnBatchID or 0) + 1
+    local spawnBatchID = self.SpawnBatchID
     
 
     local hasBoss = false
@@ -176,51 +288,107 @@ function MODE:SpawnWave()
     
     for _, npcDef in ipairs(currentWave) do
         for i = 1, npcDef.count do
+            spawnQueue[#spawnQueue + 1] = npcDef
+        end
+    end
+
+    local totalPlannedSpawns = #spawnQueue
+
+    if totalPlannedSpawns <= 0 then
+        self.WaveSpawnInProgress = false
+        return
+    end
+
+    for queueIndex, npcDef in ipairs(spawnQueue) do
+        local queuedIndex = queueIndex
+        local queuedNpcDef = npcDef
+        local timerName = "defense_spawn_" .. spawnBatchID .. "_" .. queuedIndex
+
+        self:CreateTimer(timerName, (queuedIndex - 1) * defenseSpawnStepDelay, 1, function()
+            if self.SpawnBatchID ~= spawnBatchID then
+                return
+            end
+
             local point = spawnPoints[math.random(#spawnPoints)]
-            local spawnPos = self:FindValidSpawnPoint(point.pos, spawnRadius)
+            local center = point.pos or point
+            local spawnPos = self:FindNavMeshSpawnPoint(center, 250, spawnRadius)
+
+            if not spawnPos then
+                spawnPos = self:FindNavMeshSpawnPoint(nil, 0, 0)
+            end
+
+            if not spawnPos then
+                spawnPos = self:FindValidSpawnPoint(center, 300)
+            end
             
-            if not spawnPos then 
-                continue 
+            if not spawnPos then
+                if queuedIndex == totalPlannedSpawns then
+                    self.WaveSpawnInProgress = false
+
+                    if self.NPCCount <= 0 and self:IsWaveActive() then
+                        self:EndWave()
+
+                        if self.Wave and self.TotalWaves and self.Wave < self.TotalWaves then
+                            timer.Simple(1, function()
+                                if type(self.StartNewWave) == "function" then
+                                    self:StartNewWave()
+                                end
+                            end)
+                        end
+                    end
+                end
+
+                return
             end
             
             local npc
             
-            local t = npcDef.type
+            local t = queuedNpcDef.type
             if     string.sub(t, 1, 3) == "zb_"
                 or string.sub(t, 1, 3) == "ej_"
                 or string.sub(t, 1, 5) == "beta_"
             then
-                npc = SpawnZBaseNPC(nil, npcDef.type, spawnPos, npcDef.weapon)
-            elseif string.sub(npcDef.type, 1, 10) == "terminator" or string.find(npcDef.type, "sent_vj_") then
-                npc = ents.Create(npcDef.type)
-                if not IsValid(npc) then continue end
+                npc = SpawnZBaseNPC(nil, queuedNpcDef.type, spawnPos, queuedNpcDef.weapon)
+            elseif string.sub(queuedNpcDef.type, 1, 10) == "terminator" or string.find(queuedNpcDef.type, "sent_vj_") then
+                npc = ents.Create(queuedNpcDef.type)
+                if not IsValid(npc) then
+                    if queuedIndex == totalPlannedSpawns then
+                        self.WaveSpawnInProgress = false
+                    end
+
+                    return
+                end
                 npc:SetPos(spawnPos)
                 npc:Spawn()
                 
                 npc.IsDefenseWaveNPC = true
             else
-                npc = ents.Create(npcDef.type)
+                npc = ents.Create(queuedNpcDef.type)
                 if not IsValid(npc) then 
-                    continue 
+                    if queuedIndex == totalPlannedSpawns then
+                        self.WaveSpawnInProgress = false
+                    end
+
+                    return
                 end
                 
                 npc:SetPos(spawnPos)
                 
-                if npcDef.model then
-                    npc:SetModel(npcDef.model)
+                if queuedNpcDef.model then
+                    npc:SetModel(queuedNpcDef.model)
                 end
                 
-                if npcDef.keyvalues then
-                    for key, value in pairs(npcDef.keyvalues) do
+                if queuedNpcDef.keyvalues then
+                    for key, value in pairs(queuedNpcDef.keyvalues) do
                         npc:SetKeyValue(key, value)
                     end
                 end
                 
-                if npcDef.aggressive then
+                if queuedNpcDef.aggressive then
                     npc:SetKeyValue("aggressivebehavior", "1")
                     npc:SetKeyValue("spawnflags", "256") 
                     
-                    if npcDef.type == "npc_zombie" or npcDef.type == "npc_fastzombie" or npcDef.type == "npc_poisonzombie" then
+                    if queuedNpcDef.type == "npc_zombie" or queuedNpcDef.type == "npc_fastzombie" or queuedNpcDef.type == "npc_poisonzombie" then
                         npc:SetKeyValue("incominghate", "1")
                     end
                 end
@@ -228,17 +396,27 @@ function MODE:SpawnWave()
                 npc:Spawn()
                 npc:Activate()
                 
-                if npcDef.weapon and npcDef.weapon ~= "" and not npcDef.default_weapon and 
-                   (npcDef.type == "npc_combine_s" or npcDef.type == "npc_metropolice") then
-                    npc:Give(npcDef.weapon)
+                if queuedNpcDef.weapon and queuedNpcDef.weapon ~= "" and not queuedNpcDef.default_weapon and 
+                   (queuedNpcDef.type == "npc_combine_s" or queuedNpcDef.type == "npc_metropolice") then
+                    npc:Give(queuedNpcDef.weapon)
                 end
             end
 
             if not IsValid(npc) then 
-                continue 
+                if queuedIndex == totalPlannedSpawns then
+                    self.WaveSpawnInProgress = false
+                end
+
+                return
             end
             
-            if npc:GetClass() == "zb_temporary_ent" then continue end
+            if npc:GetClass() == "zb_temporary_ent" then
+                if queuedIndex == totalPlannedSpawns then
+                    self.WaveSpawnInProgress = false
+                end
+
+                return
+            end
             
             npc.IsDefenseWaveNPC = true
             npc.DefenseNPCCountedAsDead = false
@@ -246,16 +424,14 @@ function MODE:SpawnWave()
             
             self.DefenseWaveEntities[npc.DefenseEntityID] = npc
             
-            print("[DEFENSE] Spawned NPC: " .. npcDef.type .. ", EntIndex: " .. npc:EntIndex())
+            print("[DEFENSE] Spawned NPC: " .. queuedNpcDef.type .. ", EntIndex: " .. npc:EntIndex())
             
-            table.insert(spawnedNPCs, { entity = npc, def = npcDef })
-            
-            if npcDef.health and not (string.sub(npcDef.type, 1, 3) == "zb_") then
-                npc:SetHealth(npcDef.health)
-                npc:SetMaxHealth(npcDef.health)
+            if queuedNpcDef.health and not (string.sub(queuedNpcDef.type, 1, 3) == "zb_") then
+                npc:SetHealth(queuedNpcDef.health)
+                npc:SetMaxHealth(queuedNpcDef.health)
             end
 
-            if npcDef.type == "npc_turret_floor" and npcDef.no_target then
+            if queuedNpcDef.type == "npc_turret_floor" and queuedNpcDef.no_target then
                 timer.Simple(0.5, function()
                     if IsValid(npc) then
                         npc:Fire("Enable")
@@ -266,26 +442,36 @@ function MODE:SpawnWave()
             
             
             self:AssignNPCTarget(npc)
-            self.NPCCount = self.NPCCount + 1
-        end
-    end
-    
 
-    for _, spawnedNPC in ipairs(spawnedNPCs) do
-        local npc = spawnedNPC.entity
-        local npcDef = spawnedNPC.def
-        
-        if IsValid(npc) and npcDef.relationship then
-            local targetClass = npcDef.relationship.class
-            local disposition = npcDef.relationship.disposition
-            
-            for _, targetNPC in ipairs(ents.FindByClass(targetClass)) do
-                if IsValid(targetNPC) then
-                    npc:AddEntityRelationship(targetNPC, disposition, 99)
-                    targetNPC:AddEntityRelationship(npc, disposition, 99)
+            if queuedNpcDef.relationship then
+                local targetClass = queuedNpcDef.relationship.class
+                local disposition = queuedNpcDef.relationship.disposition
+
+                for _, targetNPC in ipairs(ents.FindByClass(targetClass)) do
+                    if IsValid(targetNPC) then
+                        npc:AddEntityRelationship(targetNPC, disposition, 99)
+                        targetNPC:AddEntityRelationship(npc, disposition, 99)
+                    end
                 end
             end
-        end
+
+            self.NPCCount = self.NPCCount + 1
+            if queuedIndex == totalPlannedSpawns then
+                self.WaveSpawnInProgress = false
+
+                if self.NPCCount <= 0 and self:IsWaveActive() then
+                    self:EndWave()
+
+                    if self.Wave and self.TotalWaves and self.Wave < self.TotalWaves then
+                        timer.Simple(1, function()
+                            if type(self.StartNewWave) == "function" then
+                                self:StartNewWave()
+                            end
+                        end)
+                    end
+                end
+            end
+        end)
     end
     
     print("[DEFENSE] Wave " .. self.Wave .. " started with " .. self.NPCCount .. " NPCs")
@@ -308,7 +494,7 @@ function MODE:OnNPCKilled(npc, attacker, inflictor)
     if npc.IsDefenseWaveNPC then
         self.NPCCount = math.max(0, self.NPCCount - 1)
     
-        if self.NPCCount <= 0 then
+        if self.NPCCount <= 0 and not self.WaveSpawnInProgress then
             self:EndWave() 
             
 

--- a/lua/initpost/menu-n-derma/derma/cl_menu_options.lua
+++ b/lua/initpost/menu-n-derma/derma/cl_menu_options.lua
@@ -148,6 +148,25 @@ function hg.GetConVarType(convar)
 
     return "string"
 end
+
+local function SetConVarValue(convar, value)
+    if not convar then
+        return
+    end
+
+    local name = convar.GetName and convar:GetName()
+    if not name or name == "" then
+        return
+    end
+
+    if isbool(value) then
+        RunConsoleCommand(name, value and "1" or "0")
+        return
+    end
+
+    RunConsoleCommand(name, tostring(value))
+end
+
 local clr_1 = Color(255,255,255,104)
 local clr_2 = Color(122,122,122,104)
 local clr_3 = Color(28,28,28)
@@ -221,10 +240,11 @@ function hg.CreateButton(buttonData, convarName, ParentPanel, yPos)
         
         function toggle:DoClick()
             if convar then
-                convar:SetBool(not convar:GetBool())
+                local newValue = not convar:GetBool()
+                SetConVarValue(convar, newValue)
 
                 surface.PlaySound('glide/headlights_on.wav')
-                targetProgress = convar:GetBool() and 1 or 0
+                targetProgress = newValue and 1 or 0
             end
         end
         
@@ -241,11 +261,11 @@ function hg.CreateButton(buttonData, convarName, ParentPanel, yPos)
         slider:SetMin(min)
         slider:SetMax(max)
         slider:SetDecimals(decimals)
-        slider:SetValue(convar:GetInt())
+        slider:SetValue(decimals > 0 and convar:GetFloat() or convar:GetInt())
         
         function slider:OnValueChanged(val)
             if convar then
-                convar:SetInt(math.Round(val))
+                SetConVarValue(convar, decimals > 0 and math.Round(val, decimals) or math.Round(val))
             end
         end
         
@@ -282,7 +302,7 @@ function hg.CreateButton(buttonData, convarName, ParentPanel, yPos)
         
         function textEntry:OnValueChange(val)
             if convar then
-                convar:SetString(val)
+                SetConVarValue(convar, val)
             end
         end
     end

--- a/lua/weapons/weapon_melee.lua
+++ b/lua/weapons/weapon_melee.lua
@@ -1751,6 +1751,8 @@ end
 
 function SWEP:NPCThink()
     local npc = self:GetOwner()
+    if not IsValid(npc) or not npc:IsNPC() then return end
+
     self:SetWeaponHoldType("melee")
     
     if npc:GetClass() == "npc_metropolice" then
@@ -1764,7 +1766,7 @@ function SWEP:NPCThink()
     end
     
     local enemy = npc:GetEnemy()
-    if not enemy then return end
+    if not IsValid(enemy) then return end
 
     local dist = enemy:GetPos():Distance(npc:GetPos())
 


### PR DESCRIPTION
Major overhaul of the Defense gamemode's spawning, wave logic and vote handling, plus related UI and NPC safety fixes.

Key changes:
- Reworked player/NPC spawn system: added GetUsualPlayerSpawnPoints, GetGroundedPlayerSpawn, GetDefenseAnchorPoints, navmesh-based FindNavMeshSpawnPoint, IsValidNavMeshSpawn and visibility checks (IsSpawnVisibleToAnyPlayer). These improve spawn reliability, avoid spawning NPCs inside geometry or in players' view, and prefer navmesh areas.
- Introduced queued/batched wave spawns with per-step delay, SpawnBatchID tracking and WaveSpawnInProgress flag to avoid race conditions where a wave could end while spawns are still being scheduled.
- Expanded and replaced many custom VJ/beta zombie/combine definitions with standard NPC classes and adjusted counts, health, weapons and models in DEFENSE_WAVE_DEFINITIONS.
- Vote handling: client/server vote restrictions for option 3 were removed and zombie mode mapping adjusted (selectedMode==3 -> ZOMBIE). Vote menu button disabling for option 3 removed.
- Launch/launchability checks updated to use usual spawn points and navmesh existence.
- Player spawn/respawn improvements: set grounded spawn positions, reset local velocity, optionally set eye angles, and ensure SpawnPoints are consumed correctly.
- UI: added SetConVarValue helper and switched toggles/sliders/text entries to use RunConsoleCommand (supports booleans, ints and floats reliably).
- Weapon/NPC safety: added validity checks in weapon_melee NPCThink to ensure owner and enemy are valid before operations.
- Misc: replaced some hard-coded values (spawn radii, hull sizes, visibility thresholds) and cleaned up deprecated/unused early returns.

Overall this commit aims to make defense waves more stable, fair and compatible across maps by leveraging navmesh and safer spawn selection, while fixing vote/UI and NPC safety issues.

P.S. I didnt see a rules for pull request so text was randomly written. OwO