### PR TITLE
Fix mapvote getting stuck and breaking servers

### DIFF
--- a/gamemodes/zcity/gamemode/libraries/rtv/sv_rtv.lua
+++ b/gamemodes/zcity/gamemode/libraries/rtv/sv_rtv.lua
@@ -174,15 +174,13 @@ function zb.EndRTV()
     if endStarted then return end
 
     local winmap = table.GetWinningKey(votes)
-    if not winmap then return end
+    if not winmap then
+		winmap = "random"
+	end
 
     if winmap == "random" then
         winmap = mappull[math.random(#mappull)]
     end
-
-	if not winmap then
-		winmap = "gm_construct"
-	end
 
     local mapFamily = GetMapFamily(winmap)
     


### PR DESCRIPTION
Currently the map can get in a permanent stuck state and break the server until the map is forcefully change or the server is changed, this fixes it