### PR TITLE
Make Discord URL a global so servers can swap it out for their own

### DIFF
--- a/lua/initpost/menu-n-derma/derma/cl_menu_panel.lua
+++ b/lua/initpost/menu-n-derma/derma/cl_menu_panel.lua
@@ -2,10 +2,12 @@ local PANEL = {}
 local curent_panel 
 local red_select = Color(192,0,0)
 
+DISCORD_URL = "https://discord.gg/475EmEdTgH"
+
 local Selects = {
     {Title = "Disconnect", Func = function(luaMenu) RunConsoleCommand("disconnect") end},
     {Title = "Main Menu", Func = function(luaMenu) gui.ActivateGameUI() luaMenu:Close() end},
-    {Title = "Discord", Func = function(luaMenu) luaMenu:Close() gui.OpenURL("https://discord.gg/475EmEdTgH")  end},
+    {Title = "Discord", Func = function(luaMenu) luaMenu:Close() gui.OpenURL(DISCORD_URL)  end},
     {Title = "Traitor Role",
     GamemodeOnly = true,
     CreatedFunc = function(self, parent, luaMenu)


### PR DESCRIPTION
Would allow a server to do something like:
```lua
timer.Simple( 1, function()
    if not DISCORD_URL then return end
    DISCORD_URL = "https://discord.gg/blah"
end )
```